### PR TITLE
Update filesync.py

### DIFF
--- a/filesync.py
+++ b/filesync.py
@@ -26,7 +26,9 @@ class FileSyncEnableCommand(sublime_plugin.WindowCommand):
         global _enabled
         _enabled = not _enabled
         _preferences.set("filesync_enabled", _enabled)
-        self.rename_sidebar_menu(_enabled)
+        # ST3 does not extract the .sublime-package in Installed Packages folder, so the rename_sidebar_menu fails
+        if (not is_st3()):
+            self.rename_sidebar_menu(_enabled)
         sublime.save_settings("Preferences.sublime-settings")
         initFilesync()
 


### PR DESCRIPTION
ST3 does not extract the .sublime-package in Installed Packages folder, so the `rename_sidebar_menu` fails (`shutil.move()` command )
This behavior has been documented in [this issue](https://github.com/SublimeLinter/SublimeLinter-for-ST2/issues/374)
